### PR TITLE
add front camera functionality, opening camera by id

### DIFF
--- a/QRCodeReaderView-lib/qrcodereaderview/build.gradle
+++ b/QRCodeReaderView-lib/qrcodereaderview/build.gradle
@@ -5,7 +5,8 @@ buildscript {
     }
     dependencies {
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.0'
-        classpath 'com.github.dcendents:android-maven-plugin:1.2'
+        /* http://stackoverflow.com/questions/32988669/how-to-solve-gradle-sync-failed-error-defaultmavenfactory */
+        classpath 'com.github.dcendents:android-maven-gradle-plugin:1.3'
     }
 }
 

--- a/QRCodeReaderView-lib/qrcodereaderview/src/main/java/com/dlazaro66/qrcodereaderview/QRCodeReaderView.java
+++ b/QRCodeReaderView-lib/qrcodereaderview/src/main/java/com/dlazaro66/qrcodereaderview/QRCodeReaderView.java
@@ -66,6 +66,7 @@ public class QRCodeReaderView extends SurfaceView implements SurfaceHolder.Callb
     private int mPreviewHeight;
     private SurfaceHolder mHolder;
     private CameraManager mCameraManager;
+	private static int id = 0;
 
 	public QRCodeReaderView(Context context) {
 		super(context);
@@ -111,7 +112,7 @@ public class QRCodeReaderView extends SurfaceView implements SurfaceHolder.Callb
 	public void surfaceCreated(SurfaceHolder holder) {
 		try {
 			// Indicate camera, our View dimensions
-			mCameraManager.openDriver(holder,this.getWidth(),this.getHeight());
+			mCameraManager.openDriver(holder,this.getWidth(),this.getHeight(), id);
 		} catch (IOException e) {
 			Log.w(TAG, "Can not openDriver: "+e.getMessage());
 			mCameraManager.closeDriver();
@@ -257,7 +258,7 @@ public class QRCodeReaderView extends SurfaceView implements SurfaceHolder.Callb
     public static void setCameraDisplayOrientation(Context context, android.hardware.Camera camera) {
         if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.GINGERBREAD) {
             Camera.CameraInfo info = new Camera.CameraInfo();
-            android.hardware.Camera.getCameraInfo(0, info);
+            android.hardware.Camera.getCameraInfo(id, info);
             WindowManager windowManager = (WindowManager) context.getSystemService(Context.WINDOW_SERVICE);
             int rotation = windowManager.getDefaultDisplay().getRotation();
             int degrees = 0;
@@ -278,5 +279,9 @@ public class QRCodeReaderView extends SurfaceView implements SurfaceHolder.Callb
             camera.setDisplayOrientation(result);
         }
     }
-    
+
+
+	public static void setCameraId(int newId) {
+		id = newId;
+	}
 }

--- a/QRCodeReaderView-lib/qrcodereaderview/src/main/java/com/google/zxing/client/android/camera/open/CameraManager.java
+++ b/QRCodeReaderView-lib/qrcodereaderview/src/main/java/com/google/zxing/client/android/camera/open/CameraManager.java
@@ -71,10 +71,11 @@ public final class CameraManager {
    * @param holder The surface object which the camera will draw preview frames into.
    * @throws IOException Indicates the camera driver failed to open.
    */
-  public synchronized void openDriver(SurfaceHolder holder,int viewWidth,int viewHeight) throws IOException {
+  public synchronized void openDriver(SurfaceHolder holder,int viewWidth,int viewHeight, int id) throws IOException {
     Camera theCamera = camera;
     if (theCamera == null) {
-      theCamera = new OpenCameraManager().build().open();
+      /* For >= SDK 9, opens the camera with the specified id, otherwise, just opens the default camera. */
+      theCamera = new OpenCameraManager().build().open(id);
       if (theCamera == null) {
         throw new IOException();
       }

--- a/QRCodeReaderView-lib/qrcodereaderview/src/main/java/com/google/zxing/client/android/camera/open/DefaultOpenCameraInterface.java
+++ b/QRCodeReaderView-lib/qrcodereaderview/src/main/java/com/google/zxing/client/android/camera/open/DefaultOpenCameraInterface.java
@@ -27,7 +27,7 @@ final class DefaultOpenCameraInterface implements OpenCameraInterface {
    * Calls {@link Camera#open()}.
    */
   @Override
-  public Camera open() {
+  public Camera open(int id) {
     return Camera.open();
   }
   

--- a/QRCodeReaderView-lib/qrcodereaderview/src/main/java/com/google/zxing/client/android/camera/open/GingerbreadOpenCameraInterface.java
+++ b/QRCodeReaderView-lib/qrcodereaderview/src/main/java/com/google/zxing/client/android/camera/open/GingerbreadOpenCameraInterface.java
@@ -30,10 +30,11 @@ public final class GingerbreadOpenCameraInterface implements OpenCameraInterface
   private static final String TAG = "GingerbreadOpenCamera";
 
   /**
-   * Opens a rear-facing camera with {@link Camera#open(int)}, if one exists, or opens camera 0.
+   * Opens the camera with the specified id, if provided with a valid id. For an invalid id, opens a
+   * rear-facing camera, if one exists, or opens camera 0. Uses {@link Camera#open(int)}.
    */
   @Override
-  public Camera open() {
+  public Camera open(int id) {
     
     int numCameras = Camera.getNumberOfCameras();
     if (numCameras == 0) {
@@ -52,7 +53,10 @@ public final class GingerbreadOpenCameraInterface implements OpenCameraInterface
     }
     
     Camera camera;
-    if (index < numCameras) {
+    if (id >= 0 && id < numCameras) {
+      camera = Camera.open(id);
+      Log.i(TAG, "User specified id : "+id);
+    } else if (index < numCameras) {
       Log.i(TAG, "Opening camera #" + index);
       camera = Camera.open(index);
     } else {

--- a/QRCodeReaderView-lib/qrcodereaderview/src/main/java/com/google/zxing/client/android/camera/open/OpenCameraInterface.java
+++ b/QRCodeReaderView-lib/qrcodereaderview/src/main/java/com/google/zxing/client/android/camera/open/OpenCameraInterface.java
@@ -24,6 +24,6 @@ import android.hardware.Camera;
  */
 public interface OpenCameraInterface {
 
-  Camera open();
+  Camera open(int id);
 
 }

--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ How to use:
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_decoder);
         
+        // set camera id explicity, maybe to open a front camera
+        QRCodeReaderView.setCameraId(/* new id */);
+
         mydecoderview = (QRCodeReaderView) findViewById(R.id.qrdecoderview);
         mydecoderview.setOnQRCodeReadListener(this);
         
@@ -87,6 +90,7 @@ How to use:
 }
 ```
 
+You can find the id for the front facing camera using the code given [here](http://stackoverflow.com/questions/2779002/how-to-open-front-camera-on-android-platform).
 
 Add it to your project
 ----------------------


### PR DESCRIPTION
I modified some more zxing to add the feature for opening camera by id. For < SDK 9, it defaults to id 0. Using this, someone can pass in the id for front camera, or any other camera. I tested it on another application I'm working on for a front camera.