### PR TITLE
fix: QRCodeReaderView error  at Layout Editor

### DIFF
--- a/qrcodereaderview/src/main/java/com/dlazaro66/qrcodereaderview/QRCodeReaderView.java
+++ b/qrcodereaderview/src/main/java/com/dlazaro66/qrcodereaderview/QRCodeReaderView.java
@@ -77,7 +77,8 @@ public class QRCodeReaderView extends SurfaceView
 
       getHolder().addCallback(this);
     } else {
-      throw new RuntimeException("Error: Camera not found");
+      if (!isInEditMode())
+        throw new RuntimeException("Error: Camera not found");
     }
   }
 


### PR DESCRIPTION
refer: https://developer.android.com/reference/android/view/View.html#isInEditMode()

```
java.lang.RuntimeException: Error: Camera not found
    at com.dlazaro66.qrcodereaderview.QRCodeReaderView.<init>(QRCodeReaderView.java:80)
    at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
    at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
    at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
    at java.lang.reflect.Constructor.newInstance(Constructor.java:423)
    at org.jetbrains.android.uipreview.ViewLoader.createNewInstance(ViewLoader.java:465)
    at org.jetbrains.android.uipreview.ViewLoader.loadClass(ViewLoader.java:172)
    at org.jetbrains.android.uipreview.ViewLoader.loadView(ViewLoader.java:105)
    at com.android.tools.idea.rendering.LayoutlibCallbackImpl.loadView(LayoutlibCallbackImpl.java:186)
    at android.view.BridgeInflater.loadCustomView(BridgeInflater.java:334)
    at android.view.BridgeInflater.loadCustomView(BridgeInflater.java:345)
    at android.view.BridgeInflater.createViewFromTag(BridgeInflater.java:245)
    at android.view.LayoutInflater.createViewFromTag(LayoutInflater.java:727)
    at android.view.LayoutInflater.rInflate_Original(LayoutInflater.java:858)
    at android.view.LayoutInflater_Delegate.rInflate(LayoutInflater_Delegate.java:70)
    at android.view.LayoutInflater.rInflate(LayoutInflater.java:834)
    at android.view.LayoutInflater.rInflateChildren(LayoutInflater.java:821)
    at android.view.LayoutInflater.inflate(LayoutInflater.java:518)
    at android.view.LayoutInflater.inflate(LayoutInflater.java:397)
    at com.android.layoutlib.bridge.impl.RenderSessionImpl.inflate(RenderSessionImpl.java:324)
    at com.android.layoutlib.bridge.Bridge.createSession(Bridge.java:429)
    at com.android.ide.common.rendering.LayoutLibrary.createSession(LayoutLibrary.java:389)
    at com.android.tools.idea.rendering.RenderTask$2.compute(RenderTask.java:548)
    at com.android.tools.idea.rendering.RenderTask$2.compute(RenderTask.java:533)
    at com.intellij.openapi.application.impl.ApplicationImpl.runReadAction(ApplicationImpl.java:966)
    at com.android.tools.idea.rendering.RenderTask.createRenderSession(RenderTask.java:533)
    at com.android.tools.idea.rendering.RenderTask.lambda$inflate$53(RenderTask.java:659)
    at java.util.concurrent.FutureTask.run(FutureTask.java:266)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
    at java.lang.Thread.run(Thread.java:745)

```
