### PR TITLE
Added missing widget declaration

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Usage
 	public class DecoderActivity extends Activity implements OnQRCodeReadListener {
 
     private TextView resultTextView;
-	private QRCodeReaderView qrCodeReaderView;
+	private QRCodeReaderView mydecoderview;
 
 	@Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -70,13 +70,13 @@ Usage
 	@Override
 	protected void onResume() {
 		super.onResume();
-		qrCodeReaderView.startCamera();
+		mydecoderview.startCamera();
 	}
 	
 	@Override
 	protected void onPause() {
 		super.onPause();
-		qrCodeReaderView.stopCamera();
+		mydecoderview.stopCamera();
 	}
 }
 ```


### PR DESCRIPTION
"mydecoderview" of type "QRCodeReaderView" has no declaration. The "qrCodeReaderView" widget could be remained and use as a declaration.