### PR TITLE
Fix for multiple decoding tasks running at once.

### DIFF
--- a/qrcodereaderview/src/main/java/com/dlazaro66/qrcodereaderview/QRCodeReaderView.java
+++ b/qrcodereaderview/src/main/java/com/dlazaro66/qrcodereaderview/QRCodeReaderView.java
@@ -261,7 +261,8 @@ public class QRCodeReaderView extends SurfaceView
   // Called when camera take a frame
   @Override public void onPreviewFrame(byte[] data, Camera camera) {
     if (!mQrDecodingEnabled || decodeFrameTask != null
-        && decodeFrameTask.getStatus() == AsyncTask.Status.RUNNING) {
+        && (decodeFrameTask.getStatus() == AsyncTask.Status.RUNNING
+            || decodeFrameTask.getStatus() == AsyncTask.Status.PENDING)) {
       return;
     }
 


### PR DESCRIPTION
The `AsyncTask` status only becomes `Status.RUNNING` when the scheduler actually starts executing the AsyncTask, as long as the scheduler is busy doing other things the `AsyncTask` status will stay `Status.PENDING` even though `AsyncTask.execute()` has been called. Hence it is needed to check for the PENDING status too.