### PR TITLE
Add previewCallback to camera

### DIFF
--- a/qrcodereaderview/src/main/java/com/google/zxing/client/android/camera/CameraManager.java
+++ b/qrcodereaderview/src/main/java/com/google/zxing/client/android/camera/CameraManager.java
@@ -201,6 +201,7 @@ public final class CameraManager {
   public synchronized void startPreview() {
     OpenCamera theCamera = openCamera;
     if (theCamera != null && !previewing) {
+      theCamera.getCamera().setPreviewCallback(previewCallback);
       theCamera.getCamera().startPreview();
       previewing = true;
       autoFocusManager = new AutoFocusManager(theCamera.getCamera());


### PR DESCRIPTION
**Summary**

In case where startCamera() is called immediately after stopCamera() without restarting view - reference to previewCallback is lost and onPreviewFrame is not called any more. This line fixes the problem.

